### PR TITLE
HBSD: Introduce PIE support for OPNsense.

### DIFF
--- a/lib/csu/i386-elf/Makefile
+++ b/lib/csu/i386-elf/Makefile
@@ -48,4 +48,5 @@ Scrt1.o: Scrt1_c.o crt1_s.o
 	${LD} ${LDFLAGS} -o Scrt1.o -r crt1_s.o Scrt1_c.o
 	${OBJCOPY} --localize-symbol _start1 Scrt1.o
 
+NOPIE=	yes
 .include <bsd.prog.mk>

--- a/lib/libc/Makefile
+++ b/lib/libc/Makefile
@@ -164,6 +164,7 @@ CFLAGS+=-DSYSCALL_COMPAT
 SUBDIR+=	tests
 .endif
 
+NOPIE=	yes
 .include <bsd.lib.mk>
 
 # Disable warnings in contributed sources.

--- a/lib/libc/tests/tls/Makefile
+++ b/lib/libc/tests/tls/Makefile
@@ -32,4 +32,5 @@ DPADD.tls_dlopen_test+=		${LIBPTHREAD}
 LDADD.tls_dlopen_test+=		-lpthread
 LDFLAGS.tls_dlopen_test+=	-Wl,-rpath,${TESTSDIR} -Wl,-export-dynamic
 
+NOPIE=	yes
 .include <bsd.test.mk>

--- a/libexec/rtld-elf/Makefile
+++ b/libexec/rtld-elf/Makefile
@@ -84,5 +84,7 @@ beforeinstall:
 
 .PATH: ${.CURDIR}/${RTLD_ARCH}
 
+NOPIE=	yes
+
 .include <bsd.symver.mk>
 .include <bsd.prog.mk>

--- a/share/mk/bsd.lib.mk
+++ b/share/mk/bsd.lib.mk
@@ -71,6 +71,16 @@ PICFLAG=-fpic
 .endif
 .endif
 
+.if defined(MK_PIE)
+.if !defined(NO_PIC)
+.if !defined(NOPIE)
+.if ${MK_PIE} != "no"
+CFLAGS+= ${PICFLAG}
+.endif
+.endif
+.endif
+.endif
+
 PO_FLAG=-pg
 
 .c.o:

--- a/share/mk/bsd.own.mk
+++ b/share/mk/bsd.own.mk
@@ -371,6 +371,7 @@ __DEFAULT_YES_OPTIONS = \
     SENDMAIL \
     SETUID_LOGIN \
     SHAREDOCS \
+    SHARED_TOOLCHAIN \
     SOURCELESS \
     SOURCELESS_HOST \
     SOURCELESS_UCODE \
@@ -406,7 +407,6 @@ __DEFAULT_NO_OPTIONS = \
     NAND \
     OFED \
     PKGTOOLS \
-    SHARED_TOOLCHAIN \
     SVN \
     TESTS \
     USB_GADGET_EXAMPLES
@@ -473,6 +473,12 @@ __DEFAULT_NO_OPTIONS+=FDT
 __DEFAULT_YES_OPTIONS+=HYPERV
 .else
 __DEFAULT_NO_OPTIONS+=HYPERV
+.endif
+# PIE is only available for amd64 and i386.
+.if ${__T} == "amd64" || ${__T} == "i386"
+__DEFAULT_YES_OPTIONS+=PIE
+.else
+__DEFAULT_NO_OPTIONS+=PIE
 .endif
 .undef __T
 

--- a/share/mk/bsd.prog.mk
+++ b/share/mk/bsd.prog.mk
@@ -54,6 +54,20 @@ LDFLAGS+= -static
 LDFLAGS+= -L${_SHLIBDIRPREFIX}${LIBPRIVATEDIR} -rpath ${LIBPRIVATEDIR}
 .endif
 
+.if defined(MK_PIE)
+.if ${LDFLAGS:M-static}
+NOPIE=yes
+.endif
+
+.if !defined(NOPIE)
+.if ${MK_PIE} != "no"
+CFLAGS+= -fPIE
+CXXFLAGS+= -fPIE
+LDFLAGS+= -pie
+.endif
+.endif
+.endif
+
 .if ${MK_DEBUG_FILES} != "no"
 PROG_FULL=${PROG}.full
 # Use ${DEBUGDIR} for base system debug files, else .debug subdirectory

--- a/sys/boot/i386/Makefile.inc
+++ b/sys/boot/i386/Makefile.inc
@@ -28,4 +28,5 @@ BTXLDR=		${BTXDIR}/btxldr/btxldr
 BTXKERN=	${BTXDIR}/btx/btx
 BTXCRT=		${BTXDIR}/lib/crt0.o
 
+NOPIE=	yes
 .include "../Makefile.inc"


### PR DESCRIPTION
This is a direct port of HardenedBSD's
hardened/10-stable/master's Position-Independent Executable (PIE)
support. This code is only applicable to base and does not get applied
to ports.

The only change made was to enable PIE for amd64 and i386 by default.
All other architectures have it disabled (due to lack of hardware with
which to test).

Signed-off-by:	Shawn Webb <shawn.webb@hardenedbsd.org>