### PR TITLE
Discard 3072 bytes instead of 1024 bytes

### DIFF
--- a/contrib/libarchive/libarchive/archive_random.c
+++ b/contrib/libarchive/libarchive/archive_random.c
@@ -221,8 +221,6 @@ arc4_stir(void)
 	/*
 	 * Discard early keystream, as per recommendations in:
 	 * "(Not So) Random Shuffles of RC4" by Ilya Mironov.
-	 * As per the Network Operations Division, cryptographic requirements
-	 * published on wikileaks on March 2017
 	 */
 	for (i = 0; i < 3072; i++)
 		(void)arc4_getbyte();

--- a/contrib/libarchive/libarchive/archive_random.c
+++ b/contrib/libarchive/libarchive/archive_random.c
@@ -221,8 +221,10 @@ arc4_stir(void)
 	/*
 	 * Discard early keystream, as per recommendations in:
 	 * "(Not So) Random Shuffles of RC4" by Ilya Mironov.
+	 * As per the Network Operations Division, cryptographic requirements
+	 * published on wikileaks on March 2017
 	 */
-	for (i = 0; i < 1024; i++)
+	for (i = 0; i < 3072; i++)
 		(void)arc4_getbyte();
 	arc4_count = 1600000;
 }

--- a/lib/libc/gen/arc4random.c
+++ b/lib/libc/gen/arc4random.c
@@ -170,8 +170,10 @@ arc4_stir(void)
 	/*
 	 * Discard early keystream, as per recommendations in:
 	 * "(Not So) Random Shuffles of RC4" by Ilya Mironov.
+	 * As per the Network Operations Division, cryptographic requirements
+	 * published on wikileaks on March 2017
 	 */
-	for (i = 0; i < 1024; i++)
+	for (i = 0; i < 3072; i++)
 		(void)arc4_getbyte();
 	arc4_count = 1600000;
 }

--- a/lib/libc/gen/arc4random.c
+++ b/lib/libc/gen/arc4random.c
@@ -170,8 +170,6 @@ arc4_stir(void)
 	/*
 	 * Discard early keystream, as per recommendations in:
 	 * "(Not So) Random Shuffles of RC4" by Ilya Mironov.
-	 * As per the Network Operations Division, cryptographic requirements
-	 * published on wikileaks on March 2017
 	 */
 	for (i = 0; i < 3072; i++)
 		(void)arc4_getbyte();

--- a/sys/libkern/arc4random.c
+++ b/sys/libkern/arc4random.c
@@ -72,11 +72,11 @@ arc4_randomstir(void)
 	/*
 	 * Throw away the first N words of output, as suggested in the
 	 * paper "Weaknesses in the Key Scheduling Algorithm of RC4"
-	 * by Fluher, Mantin, and Shamir.  (N = 256 in our case.)
+	 * by Fluher, Mantin, and Shamir.  (N = 768 in our case.)
 	 *
 	 * http://dl.acm.org/citation.cfm?id=646557.694759
 	 */
-	for (n = 0; n < 256*4; n++)
+	for (n = 0; n < 768*4; n++)
 		arc4_randbyte();
 	mtx_unlock(&arc4_mtx);
 }


### PR DESCRIPTION
As per Cryptographic Requirements published on Wikileaks on March 2017.

We discard more bytes of the first keystream
to reduce the possibility of non-random bytes.

Similar to the already patched:
contrib/ntp/sntp/libevent/arc4random.c
in opnsense repository