### PR TITLE
RTSOLD force file write

### DIFF
--- a/usr.sbin/rtsold/rtsol.c
+++ b/usr.sbin/rtsold/rtsol.c
@@ -375,7 +375,13 @@ rtsol_input(int s)
 		    "OtherConfigFlag on %s is turned on", ifi->ifname);
 		ifi->otherconfig = 1;
 		CALL_SCRIPT(OTHER, NULL);
-	}
+	} else if(forceflag == 1) {
+         /* force the script as we really need the gateway */
+         warnmsg(LOG_DEBUG, __func__,
+		    "Forcing otherConfigFlag on %s", ifi->ifname);
+		ifi->otherconfig = 1;
+		CALL_SCRIPT(OTHER, NULL);
+    }
 	clock_gettime(CLOCK_MONOTONIC_FAST, &now);
 	newent_rai = 0;
 	rai = find_rainfo(ifi, &from);

--- a/usr.sbin/rtsold/rtsold.c
+++ b/usr.sbin/rtsold/rtsold.c
@@ -73,6 +73,7 @@ int Fflag = 0;	/* force setting sysctl parameters */
 int aflag = 0;
 int dflag = 0;
 int uflag = 0;
+int forceflag = 0;
 
 const char *otherconf_script;
 const char *resolvconf_script = "/sbin/resolvconf";
@@ -162,6 +163,9 @@ main(int argc, char **argv)
 			break;
 		case 'u':
 			uflag = 1;
+			break;
+        case 'w':
+			forceflag = 1;
 			break;
 		default:
 			usage();

--- a/usr.sbin/rtsold/rtsold.h
+++ b/usr.sbin/rtsold/rtsold.h
@@ -155,6 +155,7 @@ extern int dflag;
 extern int aflag;
 extern int Fflag;
 extern int uflag;
+extern int forceflag;
 extern const char *otherconf_script;
 extern const char *resolvconf_script;
 struct ifinfo *find_ifinfo(int);


### PR DESCRIPTION
This is a workaround for an incorrectly configured ISPs RADVD. 
Unless the ISP sets the 'otherconfig' flag RTSOLD will never launch the RTSOLD script. This is most likely the cause of much gnashing of teeth and various fixes around launching dhcp6c over the years. I have added the option 'w' to the command line to enable/disable the force write, I'll add an option to interfaces->settings to toggle this. 
A side effect of using the /tmp/*_v6 files is that if they do not exist then the gateways show as ~ although everything works... apart from the address in the gateways displays. I had considered using netstat to pull the gateways but with multiwan dhcp6c I don't think that's going to work easily. This way we will get the proper gateway for each interface. 