### PR TITLE
https://github.com/opnsense/src/issues/96

### DIFF
--- a/sys/dev/netmap/if_tun_netmap.h
+++ b/sys/dev/netmap/if_tun_netmap.h
@@ -111,6 +111,8 @@ netmap_tuncapture(struct ifnet *ifp, int isr, struct mbuf *m)
 	}
 	eh = mtod(m, struct ether_header *);
 	eh->ether_type = htons(isr == AF_INET6 ? ETHERTYPE_IPV6 : ETHERTYPE_IP);
+	memcpy(eh->ether_shost, "\x02\x02\x02\x02\x02\x02", ETHER_ADDR_LEN);
+	memcpy(eh->ether_dhost, "\x06\x06\x06\x06\x06\x06", ETHER_ADDR_LEN);
 	(*ifp->if_input)(ifp, m);
 	return 1; /* stolen */
 }


### PR DESCRIPTION
Current implementation for netmap(4) tun(4) support adds a pseudo
ethernet header, src/dst ethernet addresses being all zero'ed.
This seems to cause problems with hashing in the consumer
applications (i.e. Sensei / Suricata ).

Proposed patch fixes this by simply adding a more proper ethernet
pseudo header.

This got tested by us and by a Sensei user who reported this.