### PR TITLE
Update Unbound Documentation URL

### DIFF
--- a/contrib/unbound/dnscrypt/dnscrypt.c
+++ b/contrib/unbound/dnscrypt/dnscrypt.c
@@ -870,7 +870,7 @@ sodium_misuse_handler(void)
 		"dnscrypt: libsodium could not be initialized, this typically"
 		" happens when no good source of entropy is found. If you run"
 		" unbound in a chroot, make sure /dev/urandom is available. See"
-		" https://www.unbound.net/documentation/unbound.conf.html");
+		" https://nlnetlabs.nl/documentation/unbound/unbound.conf/");
 }
 
 


### PR DESCRIPTION
Similar to opnsense/core#4641, the old URL redirects to the documentation start page now, this one points directly at the unbound.conf documentation.