### PR TITLE
axgbe: add support for 1000BASE-BX single mode fiber SFP+

### DIFF
--- a/sys/dev/axgbe/xgbe-phy-v2.c
+++ b/sys/dev/axgbe/xgbe-phy-v2.c
@@ -192,6 +192,7 @@ enum xgbe_sfp_base {
 	XGBE_SFP_BASE_1000_SX,
 	XGBE_SFP_BASE_1000_LX,
 	XGBE_SFP_BASE_1000_CX,
+	XGBE_SFP_BASE_1000_BX,
 	XGBE_SFP_BASE_10000_SR,
 	XGBE_SFP_BASE_10000_LR,
 	XGBE_SFP_BASE_10000_LRM,
@@ -238,6 +239,14 @@ enum xgbe_sfp_speed {
 #define XGBE_SFP_BASE_BR_10GBE_MIN		0x64
 #define XGBE_SFP_BASE_BR_10GBE_MAX		0x68
 
+/* Single mode, length of fiber in units of km */
+#define XGBE_SFP_BASE_SM_LEN_KM			14
+#define XGBE_SFP_BASE_SM_LEN_KM_MIN		0x0A
+
+/* Single mode, length of fiber in units of 100m */
+#define XGBE_SFP_BASE_SM_LEN_100M		15
+#define XGBE_SFP_BASE_SM_LEN_100M_MIN	0x64
+
 #define XGBE_SFP_BASE_CU_CABLE_LEN		18
 
 #define XGBE_SFP_BASE_VENDOR_NAME		20
@@ -246,6 +255,16 @@ enum xgbe_sfp_speed {
 #define XGBE_SFP_BASE_VENDOR_PN_LEN		16
 #define XGBE_SFP_BASE_VENDOR_REV		56
 #define XGBE_SFP_BASE_VENDOR_REV_LEN		4
+
+/* 
+ * Optical specification compliance - denotes wavelength 
+ * for optical tranceivers
+ */
+#define XGBE_SFP_BASE_OSC			60
+#define XGBE_SFP_BASE_OSC_LEN		2
+#define XGBE_SFP_BASE_OSC_1310		0x051E
+#define XGBE_SFP_BASE_OSC_1439		0x05D2
+#define XGBE_SFP_BASE_OSC_1550		0x060E
 
 #define XGBE_SFP_BASE_CC			63
 
@@ -779,6 +798,13 @@ xgbe_phy_sfp_phy_settings(struct xgbe_prv_data *pdata)
 				XGBE_SET_SUP(&pdata->phy, 1000baseX_Full);
 		}
 		break;
+	case XGBE_SFP_BASE_1000_BX:
+		pdata->phy.speed = SPEED_1000;
+		pdata->phy.duplex = DUPLEX_FULL;
+		pdata->phy.autoneg = AUTONEG_DISABLE;
+		pdata->phy.pause_autoneg = AUTONEG_DISABLE;
+		XGBE_SET_SUP(&pdata->phy, 1000baseBX_Full);
+		break;
 	case XGBE_SFP_BASE_10000_SR:
 	case XGBE_SFP_BASE_10000_LR:
 	case XGBE_SFP_BASE_10000_LRM:
@@ -1189,6 +1215,7 @@ xgbe_phy_sfp_parse_eeprom(struct xgbe_prv_data *pdata)
 	struct xgbe_phy_data *phy_data = pdata->phy_data;
 	struct xgbe_sfp_eeprom *sfp_eeprom = &phy_data->sfp_eeprom;
 	uint8_t *sfp_base;
+	uint16_t wavelen = 0;
 
 	sfp_base = sfp_eeprom->base;
 
@@ -1212,6 +1239,8 @@ xgbe_phy_sfp_parse_eeprom(struct xgbe_prv_data *pdata)
 		phy_data->sfp_cable_len = sfp_base[XGBE_SFP_BASE_CU_CABLE_LEN];
 	} else
 		phy_data->sfp_cable = XGBE_SFP_CABLE_ACTIVE;
+
+	wavelen = (sfp_base[XGBE_SFP_BASE_OSC] << 8) | sfp_base[XGBE_SFP_BASE_OSC + 1];
 
 	/*
 	 * Determine the type of SFP. Certain 10G SFP+ modules read as
@@ -1238,7 +1267,12 @@ xgbe_phy_sfp_parse_eeprom(struct xgbe_prv_data *pdata)
 		phy_data->sfp_base = XGBE_SFP_BASE_1000_CX;
 	else if (sfp_base[XGBE_SFP_BASE_1GBE_CC] & XGBE_SFP_BASE_1GBE_CC_T)
 		phy_data->sfp_base = XGBE_SFP_BASE_1000_T;
-
+	else if (xgbe_phy_sfp_bit_rate(sfp_eeprom, XGBE_SFP_SPEED_1000)
+			&& (sfp_base[XGBE_SFP_BASE_SM_LEN_KM] >= XGBE_SFP_BASE_SM_LEN_KM_MIN
+			|| sfp_base[XGBE_SFP_BASE_SM_LEN_100M] >= XGBE_SFP_BASE_SM_LEN_100M_MIN)
+			&& wavelen >= XGBE_SFP_BASE_OSC_1310)
+		phy_data->sfp_base = XGBE_SFP_BASE_1000_BX;
+		
 	switch (phy_data->sfp_base) {
 	case XGBE_SFP_BASE_1000_T:
 		phy_data->sfp_speed = XGBE_SFP_SPEED_100_1000;
@@ -1246,6 +1280,7 @@ xgbe_phy_sfp_parse_eeprom(struct xgbe_prv_data *pdata)
 	case XGBE_SFP_BASE_1000_SX:
 	case XGBE_SFP_BASE_1000_LX:
 	case XGBE_SFP_BASE_1000_CX:
+	case XGBE_SFP_BASE_1000_BX:
 		phy_data->sfp_speed = XGBE_SFP_SPEED_1000;
 		break;
 	case XGBE_SFP_BASE_10000_SR:
@@ -1271,29 +1306,29 @@ xgbe_phy_sfp_eeprom_info(struct xgbe_prv_data *pdata,
 	struct xgbe_sfp_ascii sfp_ascii;
 	char *sfp_data = (char *)&sfp_ascii;
 
-	axgbe_printf(3, "SFP detected:\n");
+	axgbe_printf(0, "SFP detected:\n");
 	memcpy(sfp_data, &sfp_eeprom->base[XGBE_SFP_BASE_VENDOR_NAME],
 	       XGBE_SFP_BASE_VENDOR_NAME_LEN);
 	sfp_data[XGBE_SFP_BASE_VENDOR_NAME_LEN] = '\0';
-	axgbe_printf(3, "  vendor:	 %s\n",
+	axgbe_printf(0, "  vendor:	 %s\n",
 	    sfp_data);
 
 	memcpy(sfp_data, &sfp_eeprom->base[XGBE_SFP_BASE_VENDOR_PN],
 	       XGBE_SFP_BASE_VENDOR_PN_LEN);
 	sfp_data[XGBE_SFP_BASE_VENDOR_PN_LEN] = '\0';
-	axgbe_printf(3, "  part number:    %s\n",
+	axgbe_printf(0, "  part number:    %s\n",
 	    sfp_data);
 
 	memcpy(sfp_data, &sfp_eeprom->base[XGBE_SFP_BASE_VENDOR_REV],
 	       XGBE_SFP_BASE_VENDOR_REV_LEN);
 	sfp_data[XGBE_SFP_BASE_VENDOR_REV_LEN] = '\0';
-	axgbe_printf(3, "  revision level: %s\n",
+	axgbe_printf(0, "  revision level: %s\n",
 	    sfp_data);
 
 	memcpy(sfp_data, &sfp_eeprom->extd[XGBE_SFP_BASE_VENDOR_SN],
 	       XGBE_SFP_BASE_VENDOR_SN_LEN);
 	sfp_data[XGBE_SFP_BASE_VENDOR_SN_LEN] = '\0';
-	axgbe_printf(3, "  serial number:  %s\n",
+	axgbe_printf(0, "  serial number:  %s\n",
 	    sfp_data);
 }
 

--- a/sys/dev/axgbe/xgbe_osdep.h
+++ b/sys/dev/axgbe/xgbe_osdep.h
@@ -128,6 +128,7 @@ do {									\
 #define	SUPPORTED_10000baseCR_Full	(1 << 19)
 #define SUPPORTED_100baseT_Half		(1 << 20)
 #define SUPPORTED_1000baseT_Half	(1 << 21)
+#define SUPPORTED_1000baseBX_Full	(1 << 22)
 
 #define LPA_PAUSE_ASYM			0x0800
 


### PR DESCRIPTION
This commit adds support for the 1000BASE-BX single mode fiber over SFP. Included in this commit is a small log-level change to pretty-print SFP module information on a hotplug event (regardless of SFP type).

Since 1000BASE-BX always consists of 2 modules (1310/1490nm and 1490/1310nm respectively), both ends have been tested and confirmed to be working using a connection to a Netgear ProSafe MS510TX 10GbE port.