### PR TITLE
axgbe: Make sure driver works on V1000 platform and remove unnecessary reset

### DIFF
--- a/sys/dev/axgbe/if_axgbe_pci.c
+++ b/sys/dev/axgbe/if_axgbe_pci.c
@@ -392,6 +392,7 @@ axgbe_if_attach_pre(if_ctx_t ctx)
 	if_softc_ctx_t		scctx;
 	if_shared_ctx_t		sctx;
 	device_t		dev;
+	device_t		rdev;
 	unsigned int		ma_lo, ma_hi;
 	unsigned int		reg;
 
@@ -430,8 +431,15 @@ axgbe_if_attach_pre(if_ctx_t ctx)
         sc->pdata.xpcs_res = mac_res[1];
 
         /* Set the PCS indirect addressing definition registers*/
-	pdata->xpcs_window_def_reg = PCS_V2_WINDOW_DEF;
-	pdata->xpcs_window_sel_reg = PCS_V2_WINDOW_SELECT;
+	rdev = pci_find_dbsf(0, 0, 0, 0);
+	if (rdev && pci_get_device(rdev) == 0x15d0
+		&& pci_get_vendor(rdev) == 0x1022) {
+		pdata->xpcs_window_def_reg = PCS_V2_RV_WINDOW_DEF;
+		pdata->xpcs_window_sel_reg = PCS_V2_RV_WINDOW_SELECT;
+	} else {
+		pdata->xpcs_window_def_reg = PCS_V2_WINDOW_DEF;
+		pdata->xpcs_window_sel_reg = PCS_V2_WINDOW_SELECT;
+	}
 
         /* Configure the PCS indirect addressing support */
 	reg = XPCS32_IOREAD(pdata, pdata->xpcs_window_def_reg);

--- a/sys/dev/axgbe/xgbe-phy-v2.c
+++ b/sys/dev/axgbe/xgbe-phy-v2.c
@@ -1478,9 +1478,6 @@ xgbe_phy_sfp_detect(struct xgbe_prv_data *pdata)
 	struct xgbe_phy_data *phy_data = pdata->phy_data;
 	int ret, prev_sfp_state = phy_data->sfp_mod_absent;
 
-	/* Reset the SFP signals and info */
-	xgbe_phy_sfp_reset(phy_data);
-
 	ret = xgbe_phy_get_comm_ownership(pdata);
 	if (ret)
 		return;


### PR DESCRIPTION
Certain AMD chipsets use a different root complex, this can be identified during boot and used to differentiate between PCS indirection register sets, otherwise the driver will throw all kinds of curious errors when reading/writing the wrong register set.

Furthermore, a reset set up to assume a clean state for every poll iteration during link status check causes the interface to lose
it's link-up state when an I2C timeout occurs. The driver should however not assume a link-up has been lost for this reason, as timeouts are spurious and correct themselves over time. A timeout is also no clear indication of a broken link.