### PR TITLE
axgbe: make RSS and RX/TX Flow Control boot-time tunable and fix RSS initialization routine

### DIFF
--- a/sys/dev/axgbe/if_axgbe_pci.c
+++ b/sys/dev/axgbe/if_axgbe_pci.c
@@ -59,6 +59,14 @@ __FBSDID("$FreeBSD$");
 #include "ifdi_if.h"
 #include "opt_inet.h"
 #include "opt_inet6.h"
+#include "opt_rss.h"
+
+#ifdef RSS
+
+#include <net/rss_config.h>
+#include <netinet/in_rss.h>
+
+#endif
 
 MALLOC_DEFINE(M_AXGBE, "axgbe", "axgbe data");
 
@@ -105,6 +113,7 @@ static bool axgbe_if_needs_restart(if_ctx_t, enum iflib_restart_event);
 #endif
 static void axgbe_set_counts(if_ctx_t);
 static void axgbe_init_iflib_softc_ctx(struct axgbe_if_softc *);
+static void axgbe_initialize_rss_mapping(struct xgbe_prv_data *);
 
 /* MII interface registered functions */
 static int axgbe_miibus_readreg(device_t, int, int);
@@ -693,6 +702,47 @@ axgbe_init_iflib_softc_ctx(struct axgbe_if_softc *sc)
 	scctx->isc_nrxqsets_max = XGBE_MAX_QUEUES;
 
 	scctx->isc_txrx = &axgbe_txrx;
+}
+
+static void
+axgbe_initialize_rss_mapping(struct xgbe_prv_data *pdata) 
+{
+	int i;
+
+	/* Get RSS key */
+#ifdef	RSS
+	int	qid;
+	uint32_t	rss_hash_config = 0;
+
+	rss_getkey((uint8_t *)&pdata->rss_key);
+
+	rss_hash_config = rss_gethashconfig();
+
+	if (rss_hash_config & RSS_HASHTYPE_RSS_IPV4)
+		XGMAC_SET_BITS(pdata->rss_options, MAC_RSSCR, IP2TE, 1);
+	if (rss_hash_config & RSS_HASHTYPE_RSS_TCP_IPV4)
+		XGMAC_SET_BITS(pdata->rss_options, MAC_RSSCR, TCP4TE, 1);
+	if (rss_hash_config & RSS_HASHTYPE_RSS_UDP_IPV4)
+		XGMAC_SET_BITS(pdata->rss_options, MAC_RSSCR, UDP4TE, 1);
+#else
+	arc4rand(&pdata->rss_key, ARRAY_SIZE(pdata->rss_key), 0);
+
+	XGMAC_SET_BITS(pdata->rss_options, MAC_RSSCR, IP2TE, 1);
+	XGMAC_SET_BITS(pdata->rss_options, MAC_RSSCR, TCP4TE, 1);
+	XGMAC_SET_BITS(pdata->rss_options, MAC_RSSCR, UDP4TE, 1);
+#endif
+
+	/* Setup RSS lookup table */
+	for (i = 0; i < XGBE_RSS_MAX_TABLE_SIZE; i++) {
+#ifdef	RSS
+		qid = rss_get_indirection_to_bucket(i) % pdata->rx_ring_count;
+		XGMAC_SET_BITS(pdata->rss_table[i], MAC_RSSDR, DMCH, qid);
+#else
+		XGMAC_SET_BITS(pdata->rss_table[i], MAC_RSSDR, DMCH,
+				i % pdata->rx_ring_count);
+#endif
+	}
+
 }
 
 static int
@@ -1305,11 +1355,8 @@ xgbe_default_config(struct xgbe_prv_data *pdata)
         pdata->rx_sf_mode = MTL_RSF_DISABLE;
         pdata->rx_threshold = MTL_RX_THRESHOLD_64;
         pdata->pause_autoneg = 1;
-        pdata->tx_pause = 1;
-        pdata->rx_pause = 1;
         pdata->phy_speed = SPEED_UNKNOWN;
         pdata->power_down = 0;
-        pdata->enable_rss = 1;
 }
 
 static void
@@ -1333,7 +1380,7 @@ axgbe_if_attach_post(if_ctx_t ctx)
         struct xgbe_phy_if	*phy_if = &pdata->phy_if;
 	struct xgbe_hw_if 	*hw_if = &pdata->hw_if;
 	if_softc_ctx_t		scctx = sc->scctx;
-	int i, ret;
+	int ret;
 
 	/* set split header support based on tunable */
 	pdata->sph_enable = axgbe_sph_enable;
@@ -1350,6 +1397,10 @@ axgbe_if_attach_post(if_ctx_t ctx)
 	ret = hw_if->exit(&sc->pdata);
 	if (ret)
 		axgbe_error("%s: exit error %d\n", __func__, ret);
+
+	axgbe_setup_sysctl(pdata);
+
+	axgbe_sysctl_init(pdata);
 
 	/* Configure the defaults */
 	xgbe_default_config(pdata);
@@ -1386,15 +1437,7 @@ axgbe_if_attach_post(if_ctx_t ctx)
 	    scctx->isc_nrxqsets);
 	DBGPR("Channel count set to: %u\n", pdata->channel_count);
 
-	/* Get RSS key */
-#ifdef	RSS
-	rss_getkey((uint8_t *)pdata->rss_key);
-#else
-	arc4rand(&pdata->rss_key, ARRAY_SIZE(pdata->rss_key), 0);
-#endif
-	XGMAC_SET_BITS(pdata->rss_options, MAC_RSSCR, IP2TE, 1);
-	XGMAC_SET_BITS(pdata->rss_options, MAC_RSSCR, TCP4TE, 1);
-	XGMAC_SET_BITS(pdata->rss_options, MAC_RSSCR, UDP4TE, 1);
+	axgbe_initialize_rss_mapping(pdata);
 
 	/* Initialize the PHY device */
 	pdata->sysctl_an_cdr_workaround = pdata->vdata->an_cdr_workaround;
@@ -1430,11 +1473,6 @@ axgbe_if_attach_post(if_ctx_t ctx)
 	pdata->rx_buf_size = ret;
 	DBGPR("%s: rx_buf_size %d\n", __func__, ret);
 
-	/* Setup RSS lookup table */
-	for (i = 0; i < XGBE_RSS_MAX_TABLE_SIZE; i++)
-		XGMAC_SET_BITS(pdata->rss_table[i], MAC_RSSDR, DMCH,
-				i % pdata->rx_ring_count);
-
 	/* 
 	 * Mark the device down until it is initialized, which happens
 	 * when the device is accessed first (for configuring the iface,
@@ -1445,10 +1483,6 @@ axgbe_if_attach_post(if_ctx_t ctx)
 	DBGPR("mtu %d\n", ifp->if_mtu);
 	scctx->isc_max_frame_size = ifp->if_mtu + 18;
 	scctx->isc_min_frame_size = XGMAC_MIN_PACKET;
-
-	axgbe_setup_sysctl(pdata);
-
-	axgbe_sysctl_init(pdata);
 
 	axgbe_pci_init(pdata);
 

--- a/sys/dev/axgbe/xgbe-sysctl.c
+++ b/sys/dev/axgbe/xgbe-sysctl.c
@@ -1622,6 +1622,18 @@ axgbe_sysctl_init(struct xgbe_prv_data *pdata)
 	SYSCTL_ADD_UINT(clist, top, OID_AUTO, "link_workaround",
 	    CTLFLAG_RWTUN, &pdata->link_workaround, 0,
 	    "enable the workaround for link issue in coming up");
+	
+	SYSCTL_ADD_UINT(clist, top, OID_AUTO, "rss_enabled",
+		CTLFLAG_RDTUN, &pdata->enable_rss, 1,
+		"shows the RSS feature state (1 - enable, 0 - disable)");
+	
+	SYSCTL_ADD_UINT(clist, top, OID_AUTO, "tx_pause",
+		CTLFLAG_RDTUN, &pdata->tx_pause, 1,
+		"shows the Flow Control TX pause feature state (1 - enable, 0 - disable)");
+
+	SYSCTL_ADD_UINT(clist, top, OID_AUTO, "rx_pause",
+		CTLFLAG_RDTUN, &pdata->rx_pause, 1,
+		"shows the Flow Control RX pause feature state (1 - enable, 0 - disable)");
 
 	SYSCTL_ADD_PROC(clist, top, OID_AUTO, "xgmac_register",
 	    CTLTYPE_STRING | CTLFLAG_RWTUN | CTLFLAG_MPSAFE,


### PR DESCRIPTION
This change makes sure the driver correctly hooks into the RSS subsystem by:
- Checking if RSS is compiled in, and if so;
- Fetching the hash key from the RSS configuration.
- Updating the indirection table in hardware to align with the bucket arrangement. 

A bugfix is also included that makes sure the RSS key array is actually assigned data.

This commit also adds the option to enable/disable both RSS and TX/RX flow control in the hardware.