### PR TITLE
RSS: add sysctl enable toggle

### DIFF
--- a/sys/net/if_ethersubr.c
+++ b/sys/net/if_ethersubr.c
@@ -715,6 +715,12 @@ static void
 ether_init(__unused void *arg)
 {
 
+#ifdef	RSS
+	if (rss_get_enabled() == 0) {
+		ether_nh.nh_m2cpuid = NULL;
+		ether_nh.nh_policy = NETISR_POLICY_SOURCE;
+	}
+#endif
 	netisr_register(&ether_nh);
 }
 SYSINIT(ether, SI_SUB_INIT_IF, SI_ORDER_ANY, ether_init, NULL);

--- a/sys/net/if_ethersubr.c
+++ b/sys/net/if_ethersubr.c
@@ -715,7 +715,7 @@ static void
 ether_init(__unused void *arg)
 {
 
-#ifdef	RSS
+#ifdef RSS
 	if (rss_get_enabled() == 0) {
 		ether_nh.nh_m2cpuid = NULL;
 		ether_nh.nh_policy = NETISR_POLICY_SOURCE;

--- a/sys/net/if_gre.c
+++ b/sys/net/if_gre.c
@@ -663,12 +663,11 @@ gre_flowid(struct gre_softc *sc, struct mbuf *m, uint32_t af)
 			flowid = rss_hash_ip6_2tuple(
 			    &mtod(m, struct ip6_hdr *)->ip6_src,
 			    &mtod(m, struct ip6_hdr *)->ip6_dst);
-			break;
 		} else {
 			flowid = mtod(m, struct ip6_hdr *)->ip6_src.s6_addr32[3] ^
 			    mtod(m, struct ip6_hdr *)->ip6_dst.s6_addr32[3];
-			break;
 		}
+		break;
 #endif
 	default:
 		flowid = 0;

--- a/sys/net/if_gre.c
+++ b/sys/net/if_gre.c
@@ -651,12 +651,11 @@ gre_flowid(struct gre_softc *sc, struct mbuf *m, uint32_t af)
 		if (rss_get_enabled() != 0) {
 			flowid = rss_hash_ip4_2tuple(mtod(m, struct ip *)->ip_src,
 			    mtod(m, struct ip *)->ip_dst);
-			break;
 		} else {
 			flowid = mtod(m, struct ip *)->ip_src.s_addr ^
 		    	    mtod(m, struct ip *)->ip_dst.s_addr;
-			break;
 		}
+		break;
 #endif
 #ifdef INET6
 	case AF_INET6:

--- a/sys/net/if_gre.c
+++ b/sys/net/if_gre.c
@@ -667,7 +667,7 @@ gre_flowid(struct gre_softc *sc, struct mbuf *m, uint32_t af)
 			break;
 		} else {
 			flowid = mtod(m, struct ip6_hdr *)->ip6_src.s6_addr32[3] ^
-				mtod(m, struct ip6_hdr *)->ip6_dst.s6_addr32[3];
+			    mtod(m, struct ip6_hdr *)->ip6_dst.s6_addr32[3];
 			break;
 		}
 #endif

--- a/sys/net/if_gre.c
+++ b/sys/net/if_gre.c
@@ -662,8 +662,8 @@ gre_flowid(struct gre_softc *sc, struct mbuf *m, uint32_t af)
 	case AF_INET6:
 		if (rss_get_enabled() != 0) {
 			flowid = rss_hash_ip6_2tuple(
-				&mtod(m, struct ip6_hdr *)->ip6_src,
-				&mtod(m, struct ip6_hdr *)->ip6_dst);
+			    &mtod(m, struct ip6_hdr *)->ip6_src,
+			    &mtod(m, struct ip6_hdr *)->ip6_dst);
 			break;
 		} else {
 			flowid = mtod(m, struct ip6_hdr *)->ip6_src.s6_addr32[3] ^

--- a/sys/net/if_gre.c
+++ b/sys/net/if_gre.c
@@ -654,7 +654,7 @@ gre_flowid(struct gre_softc *sc, struct mbuf *m, uint32_t af)
 			break;
 		} else {
 			flowid = mtod(m, struct ip *)->ip_src.s_addr ^
-		    	mtod(m, struct ip *)->ip_dst.s_addr;
+		    	    mtod(m, struct ip *)->ip_dst.s_addr;
 			break;
 		}
 #endif

--- a/sys/net/if_gre.c
+++ b/sys/net/if_gre.c
@@ -74,6 +74,7 @@ __FBSDID("$FreeBSD$");
 #include <netinet/ip_var.h>
 #ifdef RSS
 #include <netinet/in_rss.h>
+#include <net/rss_config.h>
 #endif
 #endif
 
@@ -647,16 +648,28 @@ gre_flowid(struct gre_softc *sc, struct mbuf *m, uint32_t af)
 	switch (af) {
 #ifdef INET
 	case AF_INET:
-		flowid = rss_hash_ip4_2tuple(mtod(m, struct ip *)->ip_src,
-		    mtod(m, struct ip *)->ip_dst);
-		break;
+		if (rss_get_enabled() != 0) {
+			flowid = rss_hash_ip4_2tuple(mtod(m, struct ip *)->ip_src,
+				mtod(m, struct ip *)->ip_dst);
+			break;
+		} else {
+			flowid = mtod(m, struct ip *)->ip_src.s_addr ^
+		    	mtod(m, struct ip *)->ip_dst.s_addr;
+			break;
+		}
 #endif
 #ifdef INET6
 	case AF_INET6:
-		flowid = rss_hash_ip6_2tuple(
-		    &mtod(m, struct ip6_hdr *)->ip6_src,
-		    &mtod(m, struct ip6_hdr *)->ip6_dst);
-		break;
+		if (rss_get_enabled() != 0) {
+			flowid = rss_hash_ip6_2tuple(
+				&mtod(m, struct ip6_hdr *)->ip6_src,
+				&mtod(m, struct ip6_hdr *)->ip6_dst);
+			break;
+		} else {
+			flowid = mtod(m, struct ip6_hdr *)->ip6_src.s6_addr32[3] ^
+				mtod(m, struct ip6_hdr *)->ip6_dst.s6_addr32[3];
+			break;
+		}
 #endif
 	default:
 		flowid = 0;

--- a/sys/net/if_gre.c
+++ b/sys/net/if_gre.c
@@ -650,7 +650,7 @@ gre_flowid(struct gre_softc *sc, struct mbuf *m, uint32_t af)
 	case AF_INET:
 		if (rss_get_enabled() != 0) {
 			flowid = rss_hash_ip4_2tuple(mtod(m, struct ip *)->ip_src,
-				mtod(m, struct ip *)->ip_dst);
+			    mtod(m, struct ip *)->ip_dst);
 			break;
 		} else {
 			flowid = mtod(m, struct ip *)->ip_src.s_addr ^

--- a/sys/net/iflib.c
+++ b/sys/net/iflib.c
@@ -6468,11 +6468,7 @@ iflib_msix_init(if_ctx_t ctx)
 	queuemsgs = msgs - admincnt;
 #endif
 #ifdef RSS
-	if (rss_get_enabled() == 0) {
-		queues = queuemsgs;
-	} else {
-		queues = imin(queuemsgs, rss_getnumbuckets());
-	}
+	queues = imin(queuemsgs, rss_get_enabled() == 0 ? queuemsgs : rss_getnumbuckets());
 #else
 	queues = queuemsgs;
 #endif

--- a/sys/net/iflib.c
+++ b/sys/net/iflib.c
@@ -6468,7 +6468,11 @@ iflib_msix_init(if_ctx_t ctx)
 	queuemsgs = msgs - admincnt;
 #endif
 #ifdef RSS
-	queues = imin(queuemsgs, rss_getnumbuckets());
+	if (rss_get_enabled() == 0) {
+		queues = queuemsgs;
+	} else {
+		queues = imin(queuemsgs, rss_getnumbuckets());
+	}
 #else
 	queues = queuemsgs;
 #endif

--- a/sys/net/rss_config.c
+++ b/sys/net/rss_config.c
@@ -221,10 +221,10 @@ rss_init(__unused void *arg)
 		rss_ncpus = RSS_MAXCPUS;
 
 	/*
-	* Tune RSS table entries to be no less than 2x the number of CPUs
-	* -- unless we're running uniprocessor, in which case there's not
-	* much point in having buckets to rearrange for load-balancing!
-	*/
+	 * Tune RSS table entries to be no less than 2x the number of CPUs
+	 * -- unless we're running uniprocessor, in which case there's not
+	 * much point in having buckets to rearrange for load-balancing!
+	 */
 	if (rss_ncpus > 1) {
 		if (rss_bits == 0) {
 			rss_bits = fls(rss_ncpus - 1) + 1;

--- a/sys/net/rss_config.c
+++ b/sys/net/rss_config.c
@@ -247,7 +247,7 @@ rss_init(__unused void *arg)
 		 */
 		if (rss_bits == 0 || rss_bits > RSS_MAXBITS) {
 			RSS_DEBUG("RSS bits %u not valid, coercing to %u\n",
-				rss_bits, RSS_MAXBITS);
+			    rss_bits, RSS_MAXBITS);
 			rss_bits = RSS_MAXBITS;
 		}
 

--- a/sys/net/rss_config.c
+++ b/sys/net/rss_config.c
@@ -282,7 +282,6 @@ rss_init(__unused void *arg)
 	 * XXXRW: Not yet.  If nothing else, will require an rss_isbadkey()
 	 * loop to check for "bad" RSS keys.
 	 */
-	
 }
 SYSINIT(rss_init, SI_SUB_SOFTINTR, SI_ORDER_SECOND, rss_init, NULL);
 

--- a/sys/net/rss_config.c
+++ b/sys/net/rss_config.c
@@ -201,7 +201,7 @@ rss_init(__unused void *arg)
 
 	default:
 		RSS_DEBUG("invalid RSS hashalgo %u, coercing to %u\n",
-			rss_hashalgo, RSS_HASH_TOEPLITZ);
+		    rss_hashalgo, RSS_HASH_TOEPLITZ);
 		rss_hashalgo = RSS_HASH_TOEPLITZ;
 	}
 

--- a/sys/net/rss_config.c
+++ b/sys/net/rss_config.c
@@ -241,10 +241,10 @@ rss_init(__unused void *arg)
 			}
 		}
 		/*
-		* Microsoft limits RSS table entries to 128, so apply that
-		* limit to both auto-detected CPU counts and user-configured
-		* ones.
-		*/
+		 * Microsoft limits RSS table entries to 128, so apply that
+		 * limit to both auto-detected CPU counts and user-configured
+		 * ones.
+		 */
 		if (rss_bits == 0 || rss_bits > RSS_MAXBITS) {
 			RSS_DEBUG("RSS bits %u not valid, coercing to %u\n",
 				rss_bits, RSS_MAXBITS);

--- a/sys/net/rss_config.c
+++ b/sys/net/rss_config.c
@@ -259,7 +259,7 @@ rss_init(__unused void *arg)
 		rss_buckets = (1 << rss_bits);
 		if (rss_buckets < rss_ncpus)
 			RSS_DEBUG("WARNING: rss_buckets (%u) less than "
-				"rss_ncpus (%u)\n", rss_buckets, rss_ncpus);
+			    "rss_ncpus (%u)\n", rss_buckets, rss_ncpus);
 		rss_mask = rss_buckets - 1;
 	} else {
 		rss_bits = 0;

--- a/sys/net/rss_config.c
+++ b/sys/net/rss_config.c
@@ -277,11 +277,11 @@ rss_init(__unused void *arg)
 	}
 
 	/*
-	* Randomize rrs_key.
-	*
-	* XXXRW: Not yet.  If nothing else, will require an rss_isbadkey()
-	* loop to check for "bad" RSS keys.
-	*/
+	 * Randomize rrs_key.
+	 *
+	 * XXXRW: Not yet.  If nothing else, will require an rss_isbadkey()
+	 * loop to check for "bad" RSS keys.
+	 */
 	
 }
 SYSINIT(rss_init, SI_SUB_SOFTINTR, SI_ORDER_SECOND, rss_init, NULL);

--- a/sys/net/rss_config.c
+++ b/sys/net/rss_config.c
@@ -192,8 +192,8 @@ rss_init(__unused void *arg)
 	u_int cpuid;
 
 	/*
-	* Validate tunables, coerce to sensible values.
-	*/
+	 * Validate tunables, coerce to sensible values.
+	 */
 	switch (rss_hashalgo) {
 	case RSS_HASH_TOEPLITZ:
 	case RSS_HASH_NAIVE:

--- a/sys/net/rss_config.c
+++ b/sys/net/rss_config.c
@@ -206,11 +206,11 @@ rss_init(__unused void *arg)
 	}
 
 	/*
-	* Count available CPUs.
-	*
-	* XXXRW: Note incorrect assumptions regarding contiguity of this set
-	* elsewhere.
-	*/
+	 * Count available CPUs.
+	 *
+	 * XXXRW: Note incorrect assumptions regarding contiguity of this set
+	 * elsewhere.
+	 */
 	rss_ncpus = 0;
 	for (i = 0; i <= mp_maxid; i++) {
 		if (CPU_ABSENT(i))

--- a/sys/net/rss_config.c
+++ b/sys/net/rss_config.c
@@ -252,10 +252,10 @@ rss_init(__unused void *arg)
 		}
 
 		/*
-		* Figure out how many buckets to use; warn if less than the
-		* number of configured CPUs, although this is not a fatal
-		* problem.
-		*/
+		 * Figure out how many buckets to use; warn if less than the
+		 * number of configured CPUs, although this is not a fatal
+		 * problem.
+		 */
 		rss_buckets = (1 << rss_bits);
 		if (rss_buckets < rss_ncpus)
 			RSS_DEBUG("WARNING: rss_buckets (%u) less than "

--- a/sys/net/rss_config.c
+++ b/sys/net/rss_config.c
@@ -268,8 +268,8 @@ rss_init(__unused void *arg)
 	}
 
 	/*
-	* Set up initial CPU assignments: round-robin by default.
-	*/
+	 * Set up initial CPU assignments: round-robin by default.
+	 */
 	cpuid = CPU_FIRST();
 	for (i = 0; i < rss_buckets; i++) {
 		rss_table[i].rte_cpu = cpuid;

--- a/sys/net/rss_config.h
+++ b/sys/net/rss_config.h
@@ -110,6 +110,7 @@ extern int	rss_debug;
  * Device driver interfaces to query RSS properties that must be programmed
  * into hardware.
  */
+u_int	rss_get_enabled(void);
 u_int	rss_getbits(void);
 u_int	rss_getbucket(u_int hash);
 u_int	rss_get_indirection_to_bucket(u_int index);

--- a/sys/netinet/in_pcb.c
+++ b/sys/netinet/in_pcb.c
@@ -2037,7 +2037,8 @@ in_pcblookup_group(struct inpcbinfo *pcbinfo, struct inpcbgroup *pcbgroup,
 	 * For incoming connections, we may wish to do a wildcard
 	 * match for an RSS-local socket.
 	 */
-	if ((lookupflags & INPLOOKUP_WILDCARD) != 0) {
+	if ((lookupflags & INPLOOKUP_WILDCARD) != 0
+		&& rss_get_enabled()) {
 		struct inpcb *local_wild = NULL, *local_exact = NULL;
 #ifdef INET6
 		struct inpcb *local_wild_mapped = NULL;
@@ -2407,8 +2408,8 @@ struct inpcb *
 in_pcblookup(struct inpcbinfo *pcbinfo, struct in_addr faddr, u_int fport,
     struct in_addr laddr, u_int lport, int lookupflags, struct ifnet *ifp)
 {
-#if defined(PCBGROUP) && !defined(RSS)
-	struct inpcbgroup *pcbgroup;
+#ifdef PCBGROUP
+	struct inpcbgroup *pcbgroup = NULL;
 #endif
 
 	KASSERT((lookupflags & ~INPLOOKUP_MASK) == 0,
@@ -2426,13 +2427,19 @@ in_pcblookup(struct inpcbinfo *pcbinfo, struct in_addr faddr, u_int fport,
 	 * we could be doing RSS with a non-Toeplitz hash that is affordable
 	 * in software.
 	 */
-#if defined(PCBGROUP) && !defined(RSS)
-	if (in_pcbgroup_enabled(pcbinfo)) {
-		pcbgroup = in_pcbgroup_bytuple(pcbinfo, laddr, lport, faddr,
-		    fport);
-		return (in_pcblookup_group(pcbinfo, pcbgroup, faddr, fport,
-		    laddr, lport, lookupflags, ifp));
+#ifdef PCBGROUP
+#ifdef RSS
+	if (rss_get_enabled() == 0) {
+#endif
+		if (in_pcbgroup_enabled(pcbinfo)) {
+			pcbgroup = in_pcbgroup_bytuple(pcbinfo, laddr, lport, faddr,
+				fport);
+			return (in_pcblookup_group(pcbinfo, pcbgroup, faddr, fport,
+				laddr, lport, lookupflags, ifp));
+		}
+#ifdef RSS
 	}
+#endif
 #endif
 	return (in_pcblookup_hash(pcbinfo, faddr, fport, laddr, lport,
 	    lookupflags, ifp));

--- a/sys/netinet/in_pcb.c
+++ b/sys/netinet/in_pcb.c
@@ -2037,8 +2037,8 @@ in_pcblookup_group(struct inpcbinfo *pcbinfo, struct inpcbgroup *pcbgroup,
 	 * For incoming connections, we may wish to do a wildcard
 	 * match for an RSS-local socket.
 	 */
-	if ((lookupflags & INPLOOKUP_WILDCARD) != 0
-		&& rss_get_enabled()) {
+	if ((lookupflags & INPLOOKUP_WILDCARD) != 0 &&
+	    rss_get_enabled()) {
 		struct inpcb *local_wild = NULL, *local_exact = NULL;
 #ifdef INET6
 		struct inpcb *local_wild_mapped = NULL;

--- a/sys/netinet/in_pcbgroup.c
+++ b/sys/netinet/in_pcbgroup.c
@@ -147,17 +147,21 @@ in_pcbgroup_init(struct inpcbinfo *pcbinfo, u_int hashfields,
 		return;
 
 #ifdef RSS
-	/*
-	 * If we're using RSS, then RSS determines the number of connection
-	 * groups to use: one connection group per RSS bucket.  If for some
-	 * reason RSS isn't able to provide a number of buckets, disable
-	 * connection groups entirely.
-	 *
-	 * XXXRW: Can this ever happen?
-	 */
-	numpcbgroups = rss_getnumbuckets();
-	if (numpcbgroups == 0)
+	if (rss_get_enabled()) {
+		/*
+		 * If we're using RSS, then RSS determines the number of connection
+		 * groups to use: one connection group per RSS bucket.  If for some
+		 * reason RSS isn't able to provide a number of buckets, disable
+		 * connection groups entirely.
+		 *
+		 * XXXRW: Can this ever happen?
+		 */
+		numpcbgroups = rss_getnumbuckets();
+		if (numpcbgroups == 0)
+			return;
+	} else {
 		return;
+	}
 #else
 	/*
 	 * Otherwise, we'll just use one per CPU for now.  If we decide to

--- a/sys/netinet/ip_input.c
+++ b/sys/netinet/ip_input.c
@@ -328,12 +328,22 @@ ip_init(void)
 		printf("%s: WARNING: unable to register output helper hook\n",
 		    __func__);
 
+#ifdef	RSS
+	if (rss_get_enabled() == 0) {
+		ip_nh.nh_m2cpuid = NULL;
+		ip_nh.nh_policy = NETISR_POLICY_FLOW;
+		ip_nh.nh_dispatch = NETISR_DISPATCH_DEFAULT;
+	}
+#endif
+
 	/* Skip initialization of globals for non-default instances. */
 #ifdef VIMAGE
 	if (!IS_DEFAULT_VNET(curvnet)) {
 		netisr_register_vnet(&ip_nh);
 #ifdef	RSS
-		netisr_register_vnet(&ip_direct_nh);
+		if (rss_get_enabled()) {
+			netisr_register_vnet(&ip_direct_nh);
+		}
 #endif
 		return;
 	}
@@ -361,7 +371,9 @@ ip_init(void)
 
 	netisr_register(&ip_nh);
 #ifdef	RSS
-	netisr_register(&ip_direct_nh);
+	if (rss_get_enabled()) {
+		netisr_register(&ip_direct_nh);
+	}
 #endif
 }
 
@@ -373,7 +385,9 @@ ip_destroy(void *unused __unused)
 	int error;
 
 #ifdef	RSS
-	netisr_unregister_vnet(&ip_direct_nh);
+	if (rss_get_enabled()) {
+		netisr_unregister_vnet(&ip_direct_nh);
+	}
 #endif
 	netisr_unregister_vnet(&ip_nh);
 

--- a/sys/netinet/ip_input.c
+++ b/sys/netinet/ip_input.c
@@ -328,7 +328,7 @@ ip_init(void)
 		printf("%s: WARNING: unable to register output helper hook\n",
 		    __func__);
 
-#ifdef	RSS
+#ifdef RSS
 	if (rss_get_enabled() == 0) {
 		ip_nh.nh_m2cpuid = NULL;
 		ip_nh.nh_policy = NETISR_POLICY_FLOW;

--- a/sys/netinet/ip_reass.c
+++ b/sys/netinet/ip_reass.c
@@ -516,12 +516,12 @@ ip_reass(struct mbuf *m)
 		}
 
 		/*
-		* Queue/dispatch for reprocessing.
-		*
-		* Note: this is much slower than just handling the frame in the
-		* current receive context.  It's likely worth investigating
-		* why this is.
-		*/
+		 * Queue/dispatch for reprocessing.
+		 *
+		 * Note: this is much slower than just handling the frame in the
+		 * current receive context.  It's likely worth investigating
+		 * why this is.
+		 */
 		netisr_dispatch(NETISR_IP_DIRECT, m);
 		return (NULL);
 	}

--- a/sys/netinet/ip_reass.c
+++ b/sys/netinet/ip_reass.c
@@ -509,7 +509,7 @@ ip_reass(struct mbuf *m)
 	 * Note - this may return 1, which means the flowid in the mbuf
 	 * is correct for the configured RSS hash types and can be used.
 	 */
-	 	if (rss_get_enabled()) {
+	 if (rss_get_enabled()) {
 		if (rss_mbuf_software_hash_v4(m, 0, &rss_hash, &rss_type) == 0) {
 			m->m_pkthdr.flowid = rss_hash;
 			M_HASHTYPE_SET(m, rss_type);

--- a/sys/netinet/ip_reass.c
+++ b/sys/netinet/ip_reass.c
@@ -497,19 +497,19 @@ ip_reass(struct mbuf *m)
 #ifdef	RSS
 	if (rss_get_enabled()) {
 		/*
-		* Query the RSS layer for the flowid / flowtype for the
-		* mbuf payload.
-		*
-		* For now, just assume we have to calculate a new one.
-		* Later on we should check to see if the assigned flowid matches
-		* what RSS wants for the given IP protocol and if so, just keep it.
-		*
-		* We then queue into the relevant netisr so it can be dispatched
-		* to the correct CPU.
-		*
-		* Note - this may return 1, which means the flowid in the mbuf
-		* is correct for the configured RSS hash types and can be used.
-		*/
+		 * Query the RSS layer for the flowid / flowtype for the
+		 * mbuf payload.
+		 *
+		 * For now, just assume we have to calculate a new one.
+		 * Later on we should check to see if the assigned flowid matches
+		 * what RSS wants for the given IP protocol and if so, just keep it.
+		 *
+		 * We then queue into the relevant netisr so it can be dispatched
+		 * to the correct CPU.
+		 *
+		 * Note - this may return 1, which means the flowid in the mbuf
+		 * is correct for the configured RSS hash types and can be used.
+		 */
 		if (rss_mbuf_software_hash_v4(m, 0, &rss_hash, &rss_type) == 0) {
 			m->m_pkthdr.flowid = rss_hash;
 			M_HASHTYPE_SET(m, rss_type);

--- a/sys/netinet/ip_reass.c
+++ b/sys/netinet/ip_reass.c
@@ -495,21 +495,21 @@ ip_reass(struct mbuf *m)
 	IPQ_UNLOCK(hash);
 
 #ifdef	RSS
-	if (rss_get_enabled()) {
-		/*
-		 * Query the RSS layer for the flowid / flowtype for the
-		 * mbuf payload.
-		 *
-		 * For now, just assume we have to calculate a new one.
-		 * Later on we should check to see if the assigned flowid matches
-		 * what RSS wants for the given IP protocol and if so, just keep it.
-		 *
-		 * We then queue into the relevant netisr so it can be dispatched
-		 * to the correct CPU.
-		 *
-		 * Note - this may return 1, which means the flowid in the mbuf
-		 * is correct for the configured RSS hash types and can be used.
-		 */
+	/*
+	 * Query the RSS layer for the flowid / flowtype for the
+	 * mbuf payload.
+	 *
+	 * For now, just assume we have to calculate a new one.
+	 * Later on we should check to see if the assigned flowid matches
+	 * what RSS wants for the given IP protocol and if so, just keep it.
+	 *
+	 * We then queue into the relevant netisr so it can be dispatched
+	 * to the correct CPU.
+	 *
+	 * Note - this may return 1, which means the flowid in the mbuf
+	 * is correct for the configured RSS hash types and can be used.
+	 */
+	 	if (rss_get_enabled()) {
 		if (rss_mbuf_software_hash_v4(m, 0, &rss_hash, &rss_type) == 0) {
 			m->m_pkthdr.flowid = rss_hash;
 			M_HASHTYPE_SET(m, rss_type);

--- a/sys/netinet/tcp_hpts.c
+++ b/sys/netinet/tcp_hpts.c
@@ -1092,12 +1092,14 @@ hpts_cpuid(struct inpcb *inp){
 	}
 	/* If one is set the other must be the same */
 #ifdef	RSS
-	cpuid = rss_hash2cpuid(inp->inp_flowid, inp->inp_flowtype);
-	if (cpuid == NETISR_CPUID_NONE)
-		return (hpts_random_cpu(inp));
-	else
-		return (cpuid);
-#else
+	if (rss_get_enabled()) {
+		cpuid = rss_hash2cpuid(inp->inp_flowid, inp->inp_flowtype);
+		if (cpuid == NETISR_CPUID_NONE)
+			return (hpts_random_cpu(inp));
+		else
+			return (cpuid);
+	}
+#endif
 	/*
 	 * We don't have a flowid -> cpuid mapping, so cheat and just map
 	 * unknown cpuids to curcpu.  Not the best, but apparently better
@@ -1109,7 +1111,6 @@ hpts_cpuid(struct inpcb *inp){
 	}
 	cpuid = hpts_random_cpu(inp);
 	return (cpuid);
-#endif
 }
 
 /*

--- a/sys/netinet/tcp_timer.c
+++ b/sys/netinet/tcp_timer.c
@@ -192,12 +192,17 @@ inp_to_cpuid(struct inpcb *inp)
 	u_int cpuid;
 
 #ifdef	RSS
-	if (per_cpu_timers) {
+	if (rss_get_enabled() && per_cpu_timers) {
 		cpuid = rss_hash2cpuid(inp->inp_flowid, inp->inp_flowtype);
 		if (cpuid == NETISR_CPUID_NONE)
 			return (curcpu);	/* XXX */
 		else
 			return (cpuid);
+	} else if (per_cpu_timers) {
+		cpuid = inp->inp_flowid % (mp_maxid + 1);
+		if (! CPU_ABSENT(cpuid))
+			return (cpuid);
+		return (curcpu);
 	}
 #else
 	/* Legacy, pre-RSS behaviour */

--- a/sys/netinet/udp_usrreq.c
+++ b/sys/netinet/udp_usrreq.c
@@ -1576,7 +1576,7 @@ retry:
 		M_HASHTYPE_SET(m, flowtype);
 	}
 #ifdef	RSS
-	else {
+	else if (rss_get_enabled()) {
 		uint32_t hash_val, hash_type;
 		/*
 		 * Calculate an appropriate RSS hash for UDP and
@@ -1612,7 +1612,8 @@ retry:
 	 * currently done) or set it to some software generated
 	 * hash value based on the packet contents.
 	 */
-	ipflags |= IP_NODEFAULTFLOWID;
+	if (rss_get_enabled())
+		ipflags |= IP_NODEFAULTFLOWID;
 #endif	/* RSS */
 
 	if (unlock_udbinfo == UH_WLOCKED)

--- a/sys/netinet6/frag6.c
+++ b/sys/netinet6/frag6.c
@@ -688,7 +688,7 @@ insert:
 #ifdef RSS
 	if (rss_get_enabled()) {
 		mtag = m_tag_alloc(MTAG_ABI_IPV6, IPV6_TAG_DIRECT, sizeof(*ip6dc),
-			M_NOWAIT);
+		    M_NOWAIT);
 		if (mtag == NULL)
 			goto dropfrag;
 

--- a/sys/netinet6/frag6.c
+++ b/sys/netinet6/frag6.c
@@ -57,7 +57,9 @@ __FBSDID("$FreeBSD$");
 #include <net/netisr.h>
 #include <net/route.h>
 #include <net/vnet.h>
+#ifdef	RSS
 #include <net/rss_config.h>
+#endif
 
 #include <netinet/in.h>
 #include <netinet/in_var.h>

--- a/sys/netinet6/frag6.c
+++ b/sys/netinet6/frag6.c
@@ -705,10 +705,10 @@ insert:
 	in6_ifstat_inc(dstifp, ifs6_reass_ok);
 
 #ifdef RSS
+	/*
+	 * Queue/dispatch for reprocessing.
+	 */
 	if (rss_get_enabled()) {
-		/*
-		* Queue/dispatch for reprocessing.
-		*/
 		netisr_dispatch(NETISR_IPV6_DIRECT, m);
 		return IPPROTO_DONE;
 	}

--- a/sys/netinet6/frag6.c
+++ b/sys/netinet6/frag6.c
@@ -57,7 +57,7 @@ __FBSDID("$FreeBSD$");
 #include <net/netisr.h>
 #include <net/route.h>
 #include <net/vnet.h>
-#ifdef	RSS
+#ifdef RSS
 #include <net/rss_config.h>
 #endif
 

--- a/sys/netinet6/frag6.c
+++ b/sys/netinet6/frag6.c
@@ -57,6 +57,7 @@ __FBSDID("$FreeBSD$");
 #include <net/netisr.h>
 #include <net/route.h>
 #include <net/vnet.h>
+#include <net/rss_config.h>
 
 #include <netinet/in.h>
 #include <netinet/in_var.h>
@@ -685,16 +686,18 @@ insert:
 	}
 
 #ifdef RSS
-	mtag = m_tag_alloc(MTAG_ABI_IPV6, IPV6_TAG_DIRECT, sizeof(*ip6dc),
-	    M_NOWAIT);
-	if (mtag == NULL)
-		goto dropfrag;
+	if (rss_get_enabled()) {
+		mtag = m_tag_alloc(MTAG_ABI_IPV6, IPV6_TAG_DIRECT, sizeof(*ip6dc),
+			M_NOWAIT);
+		if (mtag == NULL)
+			goto dropfrag;
 
-	ip6dc = (struct ip6_direct_ctx *)(mtag + 1);
-	ip6dc->ip6dc_nxt = nxt;
-	ip6dc->ip6dc_off = offset;
+		ip6dc = (struct ip6_direct_ctx *)(mtag + 1);
+		ip6dc->ip6dc_nxt = nxt;
+		ip6dc->ip6dc_off = offset;
 
-	m_tag_prepend(m, mtag);
+		m_tag_prepend(m, mtag);
+	}
 #endif
 
 	IP6Q_UNLOCK(hash);
@@ -702,11 +705,13 @@ insert:
 	in6_ifstat_inc(dstifp, ifs6_reass_ok);
 
 #ifdef RSS
-	/*
-	 * Queue/dispatch for reprocessing.
-	 */
-	netisr_dispatch(NETISR_IPV6_DIRECT, m);
-	return IPPROTO_DONE;
+	if (rss_get_enabled()) {
+		/*
+		* Queue/dispatch for reprocessing.
+		*/
+		netisr_dispatch(NETISR_IPV6_DIRECT, m);
+		return IPPROTO_DONE;
+	}
 #endif
 
 	/*

--- a/sys/netinet6/in6_pcb.c
+++ b/sys/netinet6/in6_pcb.c
@@ -1313,7 +1313,7 @@ in6_pcblookup(struct inpcbinfo *pcbinfo, struct in6_addr *faddr, u_int fport,
 #endif
 		if (in_pcbgroup_enabled(pcbinfo)) {
 			pcbgroup = in6_pcbgroup_bytuple(pcbinfo, laddr, lport, faddr,
-				fport);
+			    fport);
 			return (in6_pcblookup_group(pcbinfo, pcbgroup, faddr, fport,
 				laddr, lport, lookupflags, ifp));
 		}

--- a/sys/netinet6/in6_pcb.c
+++ b/sys/netinet6/in6_pcb.c
@@ -97,7 +97,9 @@ __FBSDID("$FreeBSD$");
 #include <net/if_llatbl.h>
 #include <net/if_types.h>
 #include <net/route.h>
+#ifdef RSS
 #include <net/rss_config.h>
+#endif
 
 #include <netinet/in.h>
 #include <netinet/in_var.h>

--- a/sys/netinet6/in6_pcb.c
+++ b/sys/netinet6/in6_pcb.c
@@ -1315,7 +1315,7 @@ in6_pcblookup(struct inpcbinfo *pcbinfo, struct in6_addr *faddr, u_int fport,
 			pcbgroup = in6_pcbgroup_bytuple(pcbinfo, laddr, lport, faddr,
 			    fport);
 			return (in6_pcblookup_group(pcbinfo, pcbgroup, faddr, fport,
-				laddr, lport, lookupflags, ifp));
+			    laddr, lport, lookupflags, ifp));
 		}
 #ifdef RSS
 	}

--- a/sys/netinet6/ip6_input.c
+++ b/sys/netinet6/ip6_input.c
@@ -1643,7 +1643,7 @@ ip6_savecontrol(struct inpcb *inp, struct mbuf *m, struct mbuf **mp)
 
 			if (rss_hash2bucket(flowid, flow_type, &rss_bucketid) == 0) {
 				*mp = sbcreatecontrol((caddr_t) &rss_bucketid,
-				sizeof(uint32_t), IPV6_RSSBUCKETID, IPPROTO_IPV6);
+				    sizeof(uint32_t), IPV6_RSSBUCKETID, IPPROTO_IPV6);
 				if (*mp)
 					mp = &(*mp)->m_next;
 			}

--- a/sys/netinet6/ip6_input.c
+++ b/sys/netinet6/ip6_input.c
@@ -251,12 +251,22 @@ ip6_init(void)
 
 	V_ip6_desync_factor = arc4random() % MAX_TEMP_DESYNC_FACTOR;
 
+#ifdef RSS
+	if (rss_get_enabled() == 0) {
+		ip6_nh.nh_m2cpuid = NULL;
+		ip6_nh.nh_policy = NETISR_POLICY_FLOW;
+		ip6_nh.nh_dispatch = NETISR_DISPATCH_DEFAULT;
+	}
+#endif
+
 	/* Skip global initialization stuff for non-default instances. */
 #ifdef VIMAGE
 	if (!IS_DEFAULT_VNET(curvnet)) {
 		netisr_register_vnet(&ip6_nh);
 #ifdef RSS
-		netisr_register_vnet(&ip6_direct_nh);
+		if (rss_get_enabled()) {
+			netisr_register_vnet(&ip6_direct_nh);
+		}
 #endif
 		return;
 	}
@@ -284,7 +294,9 @@ ip6_init(void)
 
 	netisr_register(&ip6_nh);
 #ifdef RSS
-	netisr_register(&ip6_direct_nh);
+	if (rss_get_enabled()) {
+		netisr_register(&ip6_direct_nh);
+	}
 #endif
 }
 
@@ -355,7 +367,9 @@ ip6_destroy(void *unused __unused)
 	int error;
 
 #ifdef RSS
-	netisr_unregister_vnet(&ip6_direct_nh);
+	if (rss_get_enabled()) {
+		netisr_unregister_vnet(&ip6_direct_nh);
+	}
 #endif
 	netisr_unregister_vnet(&ip6_nh);
 
@@ -1619,18 +1633,20 @@ ip6_savecontrol(struct inpcb *inp, struct mbuf *m, struct mbuf **mp)
 	}
 
 #ifdef	RSS
-	if (inp->inp_flags2 & INP_RECVRSSBUCKETID) {
-		uint32_t flowid, flow_type;
-		uint32_t rss_bucketid;
+	if (rss_get_enabled()) {
+		if (inp->inp_flags2 & INP_RECVRSSBUCKETID) {
+			uint32_t flowid, flow_type;
+			uint32_t rss_bucketid;
 
-		flowid = m->m_pkthdr.flowid;
-		flow_type = M_HASHTYPE_GET(m);
+			flowid = m->m_pkthdr.flowid;
+			flow_type = M_HASHTYPE_GET(m);
 
-		if (rss_hash2bucket(flowid, flow_type, &rss_bucketid) == 0) {
-			*mp = sbcreatecontrol((caddr_t) &rss_bucketid,
-			   sizeof(uint32_t), IPV6_RSSBUCKETID, IPPROTO_IPV6);
-			if (*mp)
-				mp = &(*mp)->m_next;
+			if (rss_hash2bucket(flowid, flow_type, &rss_bucketid) == 0) {
+				*mp = sbcreatecontrol((caddr_t) &rss_bucketid,
+				sizeof(uint32_t), IPV6_RSSBUCKETID, IPPROTO_IPV6);
+				if (*mp)
+					mp = &(*mp)->m_next;
+			}
 		}
 	}
 #endif

--- a/sys/netinet6/ip6_output.c
+++ b/sys/netinet6/ip6_output.c
@@ -1732,7 +1732,9 @@ do {									\
 
 #ifdef	RSS
 				case IPV6_RECVRSSBUCKETID:
-					OPTSET2(INP_RECVRSSBUCKETID, optval);
+					if (rss_get_enabled()) {
+						OPTSET2(INP_RECVRSSBUCKETID, optval);
+					}
 					break;
 #endif
 
@@ -1773,14 +1775,16 @@ do {									\
 					break;
 #ifdef	RSS
 				case IPV6_RSS_LISTEN_BUCKET:
-					if ((optval >= 0) &&
-					    (optval < rss_getnumbuckets())) {
-						INP_WLOCK(inp);
-						inp->inp_rss_listen_bucket = optval;
-						OPTSET2_N(INP_RSS_BUCKET_SET, 1);
-						INP_WUNLOCK(inp);
-					} else {
-						error = EINVAL;
+					if (rss_get_enabled()) {
+						if ((optval >= 0) &&
+							(optval < rss_getnumbuckets())) {
+							INP_WLOCK(inp);
+							inp->inp_rss_listen_bucket = optval;
+							OPTSET2_N(INP_RSS_BUCKET_SET, 1);
+							INP_WUNLOCK(inp);
+						} else {
+							error = EINVAL;
+						}
 					}
 					break;
 #endif
@@ -2087,18 +2091,21 @@ do {									\
 					break;
 #ifdef	RSS
 				case IPV6_RSSBUCKETID:
-					retval =
-					    rss_hash2bucket(inp->inp_flowid,
-					    inp->inp_flowtype,
-					    &rss_bucket);
-					if (retval == 0)
-						optval = rss_bucket;
-					else
-						error = EINVAL;
+					if (rss_get_enabled()) {
+						retval =
+							rss_hash2bucket(inp->inp_flowid,
+							inp->inp_flowtype,
+							&rss_bucket);
+						if (retval == 0)
+							optval = rss_bucket;
+						else
+							error = EINVAL;
+					}
 					break;
 
 				case IPV6_RECVRSSBUCKETID:
-					optval = OPTBIT2(INP_RECVRSSBUCKETID);
+					if (rss_get_enabled())
+						optval = OPTBIT2(INP_RECVRSSBUCKETID);
 					break;
 #endif
 

--- a/sys/netinet6/ip6_output.c
+++ b/sys/netinet6/ip6_output.c
@@ -2093,9 +2093,9 @@ do {									\
 				case IPV6_RSSBUCKETID:
 					if (rss_get_enabled()) {
 						retval =
-							rss_hash2bucket(inp->inp_flowid,
-							inp->inp_flowtype,
-							&rss_bucket);
+						    rss_hash2bucket(inp->inp_flowid,
+						    inp->inp_flowtype,
+						    &rss_bucket);
 						if (retval == 0)
 							optval = rss_bucket;
 						else

--- a/sys/netinet6/udp6_usrreq.c
+++ b/sys/netinet6/udp6_usrreq.c
@@ -985,7 +985,7 @@ retry:
 			 * RSS / NICs grow UDP Lite protocol awareness.
 			 */
 			if (rss_proto_software_hash_v6(faddr, laddr, fport,
-				inp->inp_lport, pr, &hash_val, &hash_type) == 0) {
+			    inp->inp_lport, pr, &hash_val, &hash_type) == 0) {
 				m->m_pkthdr.flowid = hash_val;
 				M_HASHTYPE_SET(m, hash_type);
 			}

--- a/sys/netinet6/udp6_usrreq.c
+++ b/sys/netinet6/udp6_usrreq.c
@@ -963,39 +963,41 @@ retry:
 	flags = 0;
 #ifdef	RSS
 	{
-		uint32_t hash_val, hash_type;
-		uint8_t pr;
+		if (rss_get_enabled()) {
+			uint32_t hash_val, hash_type;
+			uint8_t pr;
 
-		pr = inp->inp_socket->so_proto->pr_protocol;
-		/*
-		 * Calculate an appropriate RSS hash for UDP and
-		 * UDP Lite.
-		 *
-		 * The called function will take care of figuring out
-		 * whether a 2-tuple or 4-tuple hash is required based
-		 * on the currently configured scheme.
-		 *
-		 * Later later on connected socket values should be
-		 * cached in the inpcb and reused, rather than constantly
-		 * re-calculating it.
-		 *
-		 * UDP Lite is a different protocol number and will
-		 * likely end up being hashed as a 2-tuple until
-		 * RSS / NICs grow UDP Lite protocol awareness.
-		 */
-		if (rss_proto_software_hash_v6(faddr, laddr, fport,
-		    inp->inp_lport, pr, &hash_val, &hash_type) == 0) {
-			m->m_pkthdr.flowid = hash_val;
-			M_HASHTYPE_SET(m, hash_type);
+			pr = inp->inp_socket->so_proto->pr_protocol;
+			/*
+			 * Calculate an appropriate RSS hash for UDP and
+			 * UDP Lite.
+			 *
+			 * The called function will take care of figuring out
+			 * whether a 2-tuple or 4-tuple hash is required based
+			 * on the currently configured scheme.
+			 *
+			 * Later later on connected socket values should be
+			 * cached in the inpcb and reused, rather than constantly
+			 * re-calculating it.
+			 *
+			 * UDP Lite is a different protocol number and will
+			 * likely end up being hashed as a 2-tuple until
+			 * RSS / NICs grow UDP Lite protocol awareness.
+			 */
+			if (rss_proto_software_hash_v6(faddr, laddr, fport,
+				inp->inp_lport, pr, &hash_val, &hash_type) == 0) {
+				m->m_pkthdr.flowid = hash_val;
+				M_HASHTYPE_SET(m, hash_type);
+			}
+
+			/*
+			 * Don't override with the inp cached flowid.
+			 *
+			 * Until the whole UDP path is vetted, it may actually
+			 * be incorrect.
+			 */
+			flags |= IP_NODEFAULTFLOWID;
 		}
-
-		/*
-		 * Don't override with the inp cached flowid.
-		 *
-		 * Until the whole UDP path is vetted, it may actually
-		 * be incorrect.
-		 */
-		flags |= IP_NODEFAULTFLOWID;
 	}
 #endif
 


### PR DESCRIPTION
This change allows the kernel to operate with the default netisr cpu-affinity settings while having RSS compiled in. Normally, RSS changes quite a bit of the behaviour of the kernel dispatch service - this change allows for reducing impact on incompatible hardware while preserving the option to boost throughput speeds based on packet flow CPU affinity.

Make sure to compile the following options in the kernel:
```
options  RSS
options  PCBGROUP
```

As well as setting the following sysctls:
```
net.inet.rss.enabled: 1
net.isr.bindthreads: 1
net.isr.maxthreads: -1 (automatically sets it to the number of CPUs)
```

And optionally (to force a 1:1 mapping between CPUs and buckets):
```
net.inet.rss.bits: 3 (for 8 CPUs)
net.inet.rss.bits: 2 (for 4 CPUs)
etc.
```