### PR TITLE
e1000: always enable PCSD when RSS hashing is used

### DIFF
--- a/sys/dev/e1000/if_em.c
+++ b/sys/dev/e1000/if_em.c
@@ -3260,13 +3260,8 @@ em_initialize_receive_unit(if_ctx_t ctx)
 			igb_initialize_rss_mapping(adapter);
 		else
 			em_initialize_rss_mapping(adapter);
-	}
 
- 	{
- 	 	u32 mrqc = E1000_READ_REG(hw, E1000_MRQC);
- 
-		if (mrqc)
-			rxcsum |= E1000_RXCSUM_PCSD;
+		rxcsum |= E1000_RXCSUM_PCSD;
 	}
 
 	E1000_WRITE_REG(hw, E1000_RXCSUM, rxcsum);

--- a/sys/dev/e1000/if_em.c
+++ b/sys/dev/e1000/if_em.c
@@ -3270,6 +3270,13 @@ em_initialize_receive_unit(if_ctx_t ctx)
 			em_initialize_rss_mapping(adapter);
 	}
 
+ 	{
+ 	 	u32 mrqc = E1000_READ_REG(hw, E1000_MRQC);
+ 
+		if (mrqc & E1000_MRQC_ENABLE_RSS_8Q)
+			rxcsum |= E1000_RXCSUM_PCSD;
+	}
+
 	E1000_WRITE_REG(hw, E1000_RXCSUM, rxcsum);
 
 	/*

--- a/sys/dev/e1000/if_em.c
+++ b/sys/dev/e1000/if_em.c
@@ -3232,14 +3232,6 @@ em_initialize_receive_unit(if_ctx_t ctx)
 	}
 	E1000_WRITE_REG(hw, E1000_RFCTL, rfctl);
 
-	if (adapter->rx_num_queues > 1) {
-		if (adapter->hw.mac.type >= igb_mac_min)
-			igb_initialize_rss_mapping(adapter);
-		else
-			em_initialize_rss_mapping(adapter);
-	}
-
-	mrqc = E1000_READ_REG(hw, E1000_MRQC);
 	rxcsum = E1000_READ_REG(hw, E1000_RXCSUM);
 	if (if_getcapenable(ifp) & IFCAP_RXCSUM &&
 	    adapter->hw.mac.type >= e1000_82543) {

--- a/sys/dev/e1000/if_em.c
+++ b/sys/dev/e1000/if_em.c
@@ -3171,7 +3171,7 @@ em_initialize_receive_unit(if_ctx_t ctx)
 	struct e1000_hw	*hw = &adapter->hw;
 	struct em_rx_queue *que;
 	int i;
-	u32 rctl, rxcsum, rfctl, mrqc;
+	u32 rctl, rxcsum, rfctl;
 
 	INIT_DEBUGOUT("em_initialize_receive_units: begin");
 

--- a/sys/dev/e1000/if_em.c
+++ b/sys/dev/e1000/if_em.c
@@ -3260,9 +3260,7 @@ em_initialize_receive_unit(if_ctx_t ctx)
 			if (adapter->hw.mac.type > e1000_82575)
 				rxcsum |= E1000_RXCSUM_CRCOFL;
 		}
-	} else {
-		if (mrqc & E1000_MRQC_ENABLE_RSS_8Q)
-			rxcsum |= E1000_RXCSUM_PCSD;
+	} else
 		rxcsum &= ~E1000_RXCSUM_TUOFL;
 	
 	if (adapter->rx_num_queues > 1) {

--- a/sys/dev/e1000/if_em.c
+++ b/sys/dev/e1000/if_em.c
@@ -3254,7 +3254,7 @@ em_initialize_receive_unit(if_ctx_t ctx)
 		}
 	} else
 		rxcsum &= ~E1000_RXCSUM_TUOFL;
-	
+
 	if (adapter->rx_num_queues > 1) {
 		if (adapter->hw.mac.type >= igb_mac_min)
 			igb_initialize_rss_mapping(adapter);

--- a/sys/dev/e1000/if_em.c
+++ b/sys/dev/e1000/if_em.c
@@ -3264,6 +3264,12 @@ em_initialize_receive_unit(if_ctx_t ctx)
 		if (mrqc & E1000_MRQC_ENABLE_RSS_8Q)
 			rxcsum |= E1000_RXCSUM_PCSD;
 		rxcsum &= ~E1000_RXCSUM_TUOFL;
+	
+	if (adapter->rx_num_queues > 1) {
+		if (adapter->hw.mac.type >= igb_mac_min)
+			igb_initialize_rss_mapping(adapter);
+		else
+			em_initialize_rss_mapping(adapter);
 	}
 
 	E1000_WRITE_REG(hw, E1000_RXCSUM, rxcsum);

--- a/sys/dev/e1000/if_em.c
+++ b/sys/dev/e1000/if_em.c
@@ -3265,7 +3265,7 @@ em_initialize_receive_unit(if_ctx_t ctx)
  	{
  	 	u32 mrqc = E1000_READ_REG(hw, E1000_MRQC);
  
-		if (mrqc & E1000_MRQC_ENABLE_RSS_8Q)
+		if (mrqc)
 			rxcsum |= E1000_RXCSUM_PCSD;
 	}
 


### PR DESCRIPTION
To enable RSS hashing in the NIC, the RXCSUM.PCSD bit must be set. By default, this is never set when Receive Checksum Offloading is disabled - which causes problems higher up in the stack. This commit enables this bit once the RSS initialization routine has finished.

Note: E1000_MRQC_ENABLE_RSS_8Q is the same define as E1000_MRQC_ENABLE_RSS_4Q.