### PR TITLE
rss: fix rss_get_enabled check

### DIFF
--- a/sys/netinet6/ip6_input.c
+++ b/sys/netinet6/ip6_input.c
@@ -252,7 +252,7 @@ ip6_init(void)
 	V_ip6_desync_factor = arc4random() % MAX_TEMP_DESYNC_FACTOR;
 
 #ifdef RSS
-	if (rss_get_enabled()) {
+	if (!rss_get_enabled()) {
 		ip6_nh.nh_m2cpuid = NULL;
 		ip6_nh.nh_policy = NETISR_POLICY_FLOW;
 		ip6_nh.nh_dispatch = NETISR_DISPATCH_DEFAULT;


### PR DESCRIPTION
During ip6_init, if RSS is NOT enabled, it's netisr_handler struct should be reset to the ip6 defaults, currently the opposite is performed.