### PR TITLE
axgbe: fix link flapping issue

### DIFF
--- a/sys/dev/axgbe/xgbe-common.h
+++ b/sys/dev/axgbe/xgbe-common.h
@@ -1367,6 +1367,10 @@
 #define MDIO_VEND2_PMA_CDR_CONTROL	0x8056
 #endif
 
+#ifndef MDIO_VEND2_PMA_MISC_CTRL0
+#define MDIO_VEND2_PMA_MISC_CTRL0	0x8090
+#endif
+
 #ifndef MDIO_CTRL1_SPEED1G
 #define MDIO_CTRL1_SPEED1G		(MDIO_CTRL1_SPEED10G & ~BMCR_SPEED100)
 #endif
@@ -1418,6 +1422,10 @@
 #define XGBE_PMA_CDR_TRACK_EN_MASK	0x01
 #define XGBE_PMA_CDR_TRACK_EN_OFF	0x00
 #define XGBE_PMA_CDR_TRACK_EN_ON	0x01
+
+#define XGBE_PMA_PLL_CTRL_MASK		BIT(15)
+#define XGBE_PMA_PLL_CTRL_ENABLE	BIT(15)
+#define XGBE_PMA_PLL_CTRL_DISABLE	0x0000
 
 /* Bit setting and getting macros
  *  The get macro will extract the current bit field value from within

--- a/sys/dev/axgbe/xgbe.h
+++ b/sys/dev/axgbe/xgbe.h
@@ -184,9 +184,9 @@
 #define XGBE_DMA_SYS_AWCR	0x30303030
 
 /* DMA cache settings - PCI device */
-#define XGBE_DMA_PCI_ARCR	0x00000003
-#define XGBE_DMA_PCI_AWCR	0x13131313
-#define XGBE_DMA_PCI_AWARCR	0x00000313
+#define XGBE_DMA_PCI_ARCR	0x000f0f0f
+#define XGBE_DMA_PCI_AWCR	0x0f0f0f0f
+#define XGBE_DMA_PCI_AWARCR	0x00000f0f
 
 /* DMA channel interrupt modes */
 #define XGBE_IRQ_MODE_EDGE	0


### PR DESCRIPTION
This commit is based on: https://github.com/torvalds/linux/commit/daf182d360e509a494db18666799f4e85d83dda0#
and https://github.com/torvalds/linux/commit/d75135082698140a26a56defe1bbc1b06f26a41f#diff-ccb6d31bb225693470f329d0e11a7f9ee80b30120741145ef5e9748ee061a363

See their descriptions for further information.

This fixes a long-standing issue regarding link flapping. The original issue can easily be recreated by plugging in two fiber optics SFP+ modules back-to-back on the same machine - when one of them goes up, the other goes down. 

The original commit message stated "Without the PLL control setting, the link up takes longer time in a
fixed phy configuration.". It is in fact the delay which is causing out-of-phase link issues when connecting two SFP+ ports using the same driver.