### PR TITLE
axgbe: ditch return statement in i2c_isr

### DIFF
--- a/sys/dev/axgbe/xgbe-i2c.c
+++ b/sys/dev/axgbe/xgbe-i2c.c
@@ -329,8 +329,6 @@ out:
 	if (state->ret || XI2C_GET_BITS(isr, IC_RAW_INTR_STAT, STOP_DET))
 		pdata->i2c_complete = true;
 
-	return;
-
 reissue_check:
 	/* Reissue interrupt if status is not clear */
 	if (pdata->vdata->irq_reissue_support)


### PR DESCRIPTION
This return statement might trigger an edge case in which interrupts are not reissued if no STOP condition is determined within a set amount of time. 

Based on the linux equivalent in which the return statement is also omitted. (https://github.com/torvalds/linux/blob/master/drivers/net/ethernet/amd/xgbe/xgbe-i2c.c#L313)