### PR TITLE
date: Include old and new time in audit log

### DIFF
--- a/bin/date/date.c
+++ b/bin/date/date.c
@@ -265,6 +265,7 @@ setthetime(const char *fmt, const char *p, int jflag, struct timespec *ts)
 	struct tm *lt;
 	const char *dot, *t;
 	int century;
+	struct timeval tv_from, tv_to;
 
 	lt = localtime(&ts->tv_sec);
 	if (lt == NULL)
@@ -357,16 +358,20 @@ setthetime(const char *fmt, const char *p, int jflag, struct timespec *ts)
 		utx.ut_type = OLD_TIME;
 		memset(utx.ut_id, 0, sizeof(utx.ut_id));
 		(void)gettimeofday(&utx.ut_tv, NULL);
+		tv_from = utx.ut_tv;
 		pututxline(&utx);
 		if (clock_settime(CLOCK_REALTIME, ts) != 0)
 			err(1, "clock_settime");
 		utx.ut_type = NEW_TIME;
 		(void)gettimeofday(&utx.ut_tv, NULL);
+		tv_to = utx.ut_tv;
 		pututxline(&utx);
 
 		if ((p = getlogin()) == NULL)
 			p = "???";
-		syslog(LOG_AUTH | LOG_NOTICE, "date set by %s", p);
+		syslog(LOG_AUTH | LOG_NOTICE, "date set from %ld"
+			"to %ld by %s",
+			(long)tv_from.tv_sec, (long)tv_to.tv_sec, p);
 	}
 }
 

--- a/bin/date/date.c
+++ b/bin/date/date.c
@@ -369,7 +369,7 @@ setthetime(const char *fmt, const char *p, int jflag, struct timespec *ts)
 
 		if ((p = getlogin()) == NULL)
 			p = "???";
-		syslog(LOG_AUTH | LOG_NOTICE, "date set from %ld"
+		syslog(LOG_AUTH | LOG_NOTICE, "date set from %ld "
 			"to %ld by %s",
 			(long)tv_from.tv_sec, (long)tv_to.tv_sec, p);
 	}


### PR DESCRIPTION
As part of the Security Functional Requirements in *Common Criteria*, system time synchronization requires auditability of time changes (FAU_GEN.1)