### PR TITLE
Update vmimage.subr with "noatime" - brought down disk writes to basically nothing.

### DIFF
--- a/release/tools/vmimage.subr
+++ b/release/tools/vmimage.subr
@@ -69,7 +69,7 @@ vm_install_base() {
 	echo '# Custom /etc/fstab for FreeBSD VM images' \
 		> ${DESTDIR}/etc/fstab
 	if [ "${VMFS}" != zfs ]; then
-		echo "/dev/${ROOTLABEL}/rootfs   /       ${VMFS}   rw      1       1" \
+		echo "/dev/${ROOTLABEL}/rootfs   /       ${VMFS}   rw,noatime      1       1" \
 			>> ${DESTDIR}/etc/fstab
 	fi
 	if [ -z "${NOSWAP}" ]; then


### PR DESCRIPTION
RAM logging was enabled, and with this "noatime" tweak, reduced the constant 50kb - 80kb disk writes that wear down the SSD / NVME.

before
<img width="1040" height="331" alt="image" src="https://github.com/user-attachments/assets/9a9679bb-3684-4136-a640-818b23b56732" />

after
<img width="1054" height="349" alt="image" src="https://github.com/user-attachments/assets/8851b375-a2fb-488b-9ea4-3509d6019769" />

Signed-off-by: Unicorn9x