### PR TITLE
wg(4): Check for crypto operation errors

### DIFF
--- a/sys/dev/wg/wg_crypto.c
+++ b/sys/dev/wg/wg_crypto.c
@@ -230,6 +230,8 @@ chacha20poly1305_encrypt_mbuf(struct mbuf *m, const uint64_t nonce,
 	crp.crp_cipher_key = key;
 	crp.crp_callback = crypto_callback;
 	ret = crypto_dispatch(&crp);
+	if (ret == 0)
+		ret = crp.crp_etype;
 	crypto_destroyreq(&crp);
 	return (ret);
 }
@@ -253,6 +255,8 @@ chacha20poly1305_decrypt_mbuf(struct mbuf *m, const uint64_t nonce,
 	crp.crp_cipher_key = key;
 	crp.crp_callback = crypto_callback;
 	ret = crypto_dispatch(&crp);
+	if (ret == 0)
+		ret = crp.crp_etype;
 	crypto_destroyreq(&crp);
 	if (ret)
 		return (ret);
@@ -270,9 +274,14 @@ crypto_init(void)
 		.csp_cipher_klen = CHACHA20POLY1305_KEY_SIZE,
 		.csp_flags = CSP_F_SEPARATE_AAD | CSP_F_SEPARATE_OUTPUT
 	};
-	int ret = crypto_newsession(&chacha20_poly1305_sid, &csp, CRYPTOCAP_F_SOFTWARE);
+	int ret = crypto_newsession(&chacha20_poly1305_sid, &csp,
+	    CRYPTOCAP_F_SOFTWARE);
 	if (ret != 0)
 		return (ret);
+	if (!CRYPTO_SESS_SYNC(chacha20_poly1305_sid)) {
+		crypto_freesession(chacha20_poly1305_sid);
+		return (ENXIO);
+	}
 	return (0);
 }
 

--- a/sys/opencrypto/crypto.c
+++ b/sys/opencrypto/crypto.c
@@ -61,6 +61,7 @@
 #include <sys/param.h>
 #include <sys/systm.h>
 #include <sys/counter.h>
+#include <sys/fail.h>
 #include <sys/kernel.h>
 #include <sys/kthread.h>
 #include <sys/linker.h>
@@ -144,6 +145,9 @@ static	struct mtx crypto_q_mtx;
 
 SYSCTL_NODE(_kern, OID_AUTO, crypto, CTLFLAG_RW, 0,
     "In-kernel cryptography");
+
+static SYSCTL_NODE(_debug_fail_point, OID_AUTO, crypto, CTLFLAG_RW, 0,
+    "OCF fail points");
 
 /*
  * Taskqueue used to dispatch the crypto requests submitted with
@@ -1666,6 +1670,17 @@ crypto_clonereq(struct cryptop *crp, crypto_session_t cses, int how)
 void
 crypto_done(struct cryptop *crp)
 {
+	if (crp->crp_etype == 0) {
+		switch (crp->crp_session->csp.csp_mode) {
+		case CSP_MODE_DIGEST:
+		case CSP_MODE_AEAD:
+			if ((crp->crp_op & CRYPTO_OP_VERIFY_DIGEST) != 0)
+				KFAIL_POINT_CODE(_debug_fail_point_crypto,
+				    inject_badmsg, crp->crp_etype = EBADMSG);
+			break;
+		}
+	}
+
 	if (crp->crp_etype != 0)
 		CRYPTOSTAT_INC(cs_errs);
 


### PR DESCRIPTION
In particular, handle authentication errors due to bad MACs when decrypting packets.

Since the current dispatch code assumes synchronous OCF sessions by design, explicitly reject any created OCF session that is not synchronous.  Software sessions are always synchronous in practice, so this should be a nop.

Approved by:	so
Security:	FreeBSD-SA-26:52.if_wg
Security:	CVE-2026-58085
Reviewed by:	markj
Sponsored by:	Chelsio Communications